### PR TITLE
Add tenant support with global scope

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class Customer extends Authenticatable
 {
@@ -28,11 +31,23 @@ class Customer extends Authenticatable
         'long',
         'lat',
         'ktp',
+        'tenant_id',
     ];
 
     protected $casts = [
         'last_login' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
 
     public function recharges(): HasMany
     {
@@ -42,5 +57,10 @@ class Customer extends Authenticatable
     public function recharge(): HasOne
     {
         return $this->hasOne(UserRecharge::class);
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }

--- a/app/Models/PaymentGateway.php
+++ b/app/Models/PaymentGateway.php
@@ -6,6 +6,8 @@ use App\Enum\PaymentGatewayStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class PaymentGateway extends Model
 {
@@ -28,6 +30,7 @@ class PaymentGateway extends Model
         'expired_date',
         'paid_date',
         'status',
+        'tenant_id',
     ];
 
     protected $casts = [
@@ -44,5 +47,21 @@ class PaymentGateway extends Model
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -12,6 +12,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class Plan extends Model
 {
@@ -36,6 +38,7 @@ class Plan extends Model
         'pool_id',
         'pool_expired_id',
         'enabled',
+        'tenant_id',
     ];
 
     protected $casts = [
@@ -95,5 +98,21 @@ class Plan extends Model
     public function vouchers(): HasMany
     {
         return $this->hasMany(Voucher::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }

--- a/app/Models/Router.php
+++ b/app/Models/Router.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class Router extends Model
 {
@@ -17,6 +20,7 @@ class Router extends Model
         'password',
         'description',
         'enabled',
+        'tenant_id',
     ];
 
     protected $appends = [
@@ -31,5 +35,21 @@ class Router extends Model
     public function getStatusAttribute(): string
     {
         return $this->enabled ? 'Enabled' : 'Disabled';
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Tenant extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function customers(): HasMany
+    {
+        return $this->hasMany(Customer::class);
+    }
+
+    public static function currentId(): ?int
+    {
+        return auth()->user()->tenant_id ?? null;
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use App\Enum\PlanType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class Transaction extends Model
 {
@@ -20,6 +23,7 @@ class Transaction extends Model
         'method',
         'routers',
         'type',
+        'tenant_id',
     ];
 
     protected $casts = [
@@ -27,4 +31,20 @@ class Transaction extends Model
         'recharged_at' => 'datetime',
         'expired_at' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use App\Enum\UserType;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class User extends Authenticatable
 {
@@ -21,6 +24,7 @@ class User extends Authenticatable
         'password',
         'user_type',
         'last_login',
+        'tenant_id',
     ];
 
     /**
@@ -43,6 +47,22 @@ class User extends Authenticatable
         'user_type' => UserType::class,
         'last_login' => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
 
     public function getIsAdminAttribute(): bool
     {

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -7,6 +7,8 @@ use App\Enum\VoucherStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Scopes\TenantScope;
+use App\Models\Tenant;
 
 class Voucher extends Model
 {
@@ -19,6 +21,7 @@ class Voucher extends Model
         'type',
         'code',
         'status',
+        'tenant_id',
     ];
 
     protected $casts = [
@@ -39,5 +42,21 @@ class Voucher extends Model
     public function customer(): BelongsTo
     {
         return $this->belongsTo(Customer::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TenantScope);
+
+        static::creating(function ($model) {
+            if (Tenant::currentId() && !$model->tenant_id) {
+                $model->tenant_id = Tenant::currentId();
+            }
+        });
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }

--- a/app/Scopes/TenantScope.php
+++ b/app/Scopes/TenantScope.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Scopes;
+
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class TenantScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        if ($tenantId = Tenant::currentId()) {
+            $builder->where($model->getTable().'.tenant_id', $tenantId);
+        }
+    }
+}

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -4,6 +4,7 @@ use App\Enum\UserType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Tenant;
 
 return new class extends Migration
 {
@@ -14,6 +15,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->string('username')->unique();
             $table->string('fullname');
             $table->string('password');

--- a/database/migrations/2024_01_09_160622_create_customers_table.php
+++ b/database/migrations/2024_01_09_160622_create_customers_table.php
@@ -4,6 +4,7 @@ use App\Enum\ServiceType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Tenant;
 
 return new class extends Migration
 {
@@ -14,6 +15,7 @@ return new class extends Migration
     {
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->string('username', 45)->unique();
             $table->string('password');
             $table->string('pppoe_password')->comment('For PPPOE Login');

--- a/database/migrations/2024_01_09_162020_create_routers_table.php
+++ b/database/migrations/2024_01_09_162020_create_routers_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Tenant;
 
 return new class extends Migration
 {
@@ -13,6 +14,7 @@ return new class extends Migration
     {
         Schema::create('routers', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->string('name', 32);
             $table->string('ip_address', 128);
             $table->string('username', 50);

--- a/database/migrations/2024_01_09_163841_create_plans_table.php
+++ b/database/migrations/2024_01_09_163841_create_plans_table.php
@@ -9,6 +9,7 @@ use App\Enum\ValidityUnit;
 use App\Models\Bandwidth;
 use App\Models\Pool;
 use App\Models\Router;
+use App\Models\Tenant;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -22,6 +23,7 @@ return new class extends Migration
     {
         Schema::create('plans', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->foreignIdFor(Bandwidth::class)->constrained();
             $table->foreignIdFor(Router::class)->nullable()->constrained();

--- a/database/migrations/2024_01_09_164000_create_payment_gateways_table.php
+++ b/database/migrations/2024_01_09_164000_create_payment_gateways_table.php
@@ -3,6 +3,7 @@
 use App\Enum\PaymentGatewayStatus;
 use App\Models\Plan;
 use App\Models\Router;
+use App\Models\Tenant;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -16,6 +17,7 @@ return new class extends Migration
     {
         Schema::create('payment_gateways', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Router::class)->constrained();
             $table->foreignIdFor(Plan::class)->constrained();
             $table->string('username', 32);

--- a/database/migrations/2024_01_09_170019_create_transactions_table.php
+++ b/database/migrations/2024_01_09_170019_create_transactions_table.php
@@ -4,6 +4,7 @@ use App\Enum\PlanType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Tenant;
 
 return new class extends Migration
 {
@@ -14,6 +15,7 @@ return new class extends Migration
     {
         Schema::create('transactions', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->string('invoice', 25);
             $table->string('username', 32);
             $table->string('plan_name', 40);

--- a/database/migrations/2024_01_09_170633_create_vouchers_table.php
+++ b/database/migrations/2024_01_09_170633_create_vouchers_table.php
@@ -5,6 +5,7 @@ use App\Enum\VoucherStatus;
 use App\Models\Customer;
 use App\Models\Plan;
 use App\Models\Router;
+use App\Models\Tenant;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -18,6 +19,7 @@ return new class extends Migration
     {
         Schema::create('vouchers', function (Blueprint $table) {
             $table->id();
+            $table->foreignIdFor(Tenant::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Plan::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Router::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Customer::class)->nullable()->constrained()->cascadeOnDelete();

--- a/database/migrations/2024_05_08_000000_create_tenants_table.php
+++ b/database/migrations/2024_05_08_000000_create_tenants_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tenants', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tenants');
+    }
+};


### PR DESCRIPTION
## Summary
- add tenants table and model
- add tenant_id to core tables and models
- introduce TenantScope to filter queries by active tenant

## Testing
- `php -l app/Models/User.php app/Models/Customer.php app/Models/Plan.php app/Models/Router.php app/Models/PaymentGateway.php app/Models/Transaction.php app/Models/Voucher.php app/Models/Tenant.php app/Scopes/TenantScope.php database/migrations/2014_10_12_000000_create_users_table.php database/migrations/2024_01_09_160622_create_customers_table.php database/migrations/2024_01_09_162020_create_routers_table.php database/migrations/2024_01_09_163841_create_plans_table.php database/migrations/2024_01_09_164000_create_payment_gateways_table.php database/migrations/2024_01_09_170019_create_transactions_table.php database/migrations/2024_01_09_170633_create_vouchers_table.php database/migrations/2024_05_08_000000_create_tenants_table.php`
- `composer install` *(failed: 403 GitHub response; cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6896902bd0bc83249428766be0ef9331