### PR TITLE
Add tenant context middleware and helper

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,7 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'tenant' => \App\Http\Middleware\SetTenant::class,
     ];
 
     protected $routeMiddleware = [

--- a/app/Http/Middleware/SetTenant.php
+++ b/app/Http/Middleware/SetTenant.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Tenant as TenantModel;
+use App\Support\Tenant;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetTenant
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $tenant = null;
+
+        if ($header = $request->header('X-Tenant')) {
+            $tenant = TenantModel::where('name', $header)->first();
+        } else {
+            $host = $request->getHost();
+            $parts = explode('.', $host);
+            if (count($parts) > 2) {
+                $subdomain = $parts[0];
+                $tenant = TenantModel::where('name', $subdomain)->first();
+            }
+        }
+
+        Tenant::set($tenant);
+
+        return $next($request);
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Support\Tenant as TenantContext;
 
 class Tenant extends Model
 {
@@ -26,6 +27,6 @@ class Tenant extends Model
 
     public static function currentId(): ?int
     {
-        return auth()->user()->tenant_id ?? null;
+        return TenantContext::currentId();
     }
 }

--- a/app/Support/Tenant.php
+++ b/app/Support/Tenant.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Tenant as TenantModel;
+
+class Tenant
+{
+    protected static ?TenantModel $tenant = null;
+
+    public static function set(?TenantModel $tenant): void
+    {
+        self::$tenant = $tenant;
+    }
+
+    public static function current(): ?TenantModel
+    {
+        return self::$tenant;
+    }
+
+    public static function currentId(): ?int
+    {
+        return self::$tenant?->id;
+    }
+}

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -15,7 +15,7 @@ use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
-Route::name('admin:')->group(function () {
+Route::middleware('tenant')->name('admin:')->group(function () {
     Route::middleware('guest:admin')
         ->group(function () {
             Route::get('login', [AdminAuthController::class, 'create'])->name('auth.login');

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+Route::middleware(['auth:sanctum', 'tenant'])->get('/user', function (Request $request) {
     return $request->user();
 });

--- a/routes/customer.php
+++ b/routes/customer.php
@@ -17,30 +17,32 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('auth.login');
-})->middleware('guest');
+Route::middleware('tenant')->group(function () {
+    Route::get('/', function () {
+        return view('auth.login');
+    })->middleware('guest');
 
-Route::middleware('auth')->group(function () {
+    Route::middleware('auth')->group(function () {
 
-    Route::name('customer:')->prefix('customer')->group(function () {
-        Route::view('/dashboard', 'customer.dashboard')->name('dashboard');
-        Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-        Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-        Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-        Route::put('password', [PasswordController::class, 'update'])->name('password.update');
-        Route::get('/voucher', [CustomerVoucherController::class, 'voucher'])->name('voucher.create');
-        Route::post('/voucher/activate', [CustomerVoucherController::class, 'voucherActivate'])->name('voucher.activate');
-        Route::get('/history/voucher', [CustomerVoucherController::class, 'voucherHistory'])->name('history.voucher');
+        Route::name('customer:')->prefix('customer')->group(function () {
+            Route::view('/dashboard', 'customer.dashboard')->name('dashboard');
+            Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+            Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+            Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+            Route::put('password', [PasswordController::class, 'update'])->name('password.update');
+            Route::get('/voucher', [CustomerVoucherController::class, 'voucher'])->name('voucher.create');
+            Route::post('/voucher/activate', [CustomerVoucherController::class, 'voucherActivate'])->name('voucher.activate');
+            Route::get('/history/voucher', [CustomerVoucherController::class, 'voucherHistory'])->name('history.voucher');
 
-        // ORDER #
-        Route::get('order', [CustomerOrderController::class, 'index'])->name('order.index');
-        Route::get('order/{plan}', [CustomerOrderController::class, 'buy'])->name('order.buy');
-        Route::get('order/{order}/detail', [CustomerOrderController::class, 'detail'])->name('order.detail');
-        Route::get('order/{order}/check', [CustomerOrderController::class, 'check'])->name('order.check');
-        Route::get('order/{order}/cancel', [CustomerOrderController::class, 'cancel'])->name('order.cancel');
-        Route::get('/history/order', [CustomerOrderController::class, 'history'])->name('history.order');
+            // ORDER #
+            Route::get('order', [CustomerOrderController::class, 'index'])->name('order.index');
+            Route::get('order/{plan}', [CustomerOrderController::class, 'buy'])->name('order.buy');
+            Route::get('order/{order}/detail', [CustomerOrderController::class, 'detail'])->name('order.detail');
+            Route::get('order/{order}/check', [CustomerOrderController::class, 'check'])->name('order.check');
+            Route::get('order/{order}/cancel', [CustomerOrderController::class, 'cancel'])->name('order.cancel');
+            Route::get('/history/order', [CustomerOrderController::class, 'history'])->name('history.order');
+        });
     });
-});
 
-require __DIR__.'/auth.php';
+    require __DIR__.'/auth.php';
+});


### PR DESCRIPTION
## Summary
- add SetTenant middleware to derive tenant from subdomain or header
- register tenant middleware and use it on tenant-aware routes
- introduce Tenant helper for retrieving current tenant

## Testing
- `php -l app/Support/Tenant.php app/Http/Middleware/SetTenant.php app/Models/Tenant.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896e6cf259c83249a36e057ff0fc28a